### PR TITLE
set frame fill to NA to avoid white squares

### DIFF
--- a/R/bertinplot.R
+++ b/R/bertinplot.R
@@ -155,7 +155,8 @@ bertinplot <-
       ## do frame
       if(options$frame) grid.rect(x = 1:length(value),
         width = 1,
-        default.units = "native")
+        default.units = "native", 
+        gp = gpar(fill = NA))
 
       upViewport(1)
     }


### PR DESCRIPTION
While testing your package and working with the vignette I noticed that I only got white squares when using `frame = TRUE` within the `bertinplot()` function; see: 

![screenshot 2019-01-06 20 50 37](https://user-images.githubusercontent.com/6630811/50740871-f49b7800-11f5-11e9-917c-42ebdf1abed8.png)

Only with tinkering around I notices that the squares or circles are drawn but that `frame = TRUE` created squares with white fill on top of them; see here with `panel = panel.circles` and `spacing = -1` (so that the circles become larger than the squares): 

![screenshot 2019-01-06 20 14 39](https://user-images.githubusercontent.com/6630811/50740903-6e336600-11f6-11e9-8bab-bbd5a4e58ed4.png)

I tried to fix this by setting the `fill = NA` at [bertinplot.R](https://github.com/mhahsler/seriation/blob/master/R/bertinplot.R#L158), but am not sure if this might only be an issue due to changes in dependencies? This 'rough' fix gives the desired output:

![screenshot 2019-01-06 20 14 54](https://user-images.githubusercontent.com/6630811/50740961-22cd8780-11f7-11e9-8bda-dec745047142.png)

Near-term goal is to understand Seriation better by reproducing the results of [Jeunesse et al. - 2009 - Die pfälzische Bandkeramik Definition und Periodisierung](https://www.academia.edu/16678547/Die_pf%C3%A4lzische_Bandkeramik_Definition_und_Periodisierung_einer_neuen_Regionalgruppe_der_Linearbandkeramik_In_Zeeb-Lanz_A._dir) that was obtained using WinBASP.

![screenshot 2019-01-06 21 10 46](https://user-images.githubusercontent.com/6630811/50740993-98395800-11f7-11e9-9c9e-dedf95d18821.png)
