### PR TITLE
fixes seriate.dist error message upon NAs in x

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: seriation
 Type: Package
 Title: Infrastructure for Ordering Objects Using Seriation
-Version: 1.3.6
+Version: 1.3.6.9000
 Date: 2022-07-14
 Authors@R: c(
 	person("Michael", "Hahsler", role = c("aut", "cre", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# seriation (development version)
+
+## Bug Fixes
+
+-   seriate.dist now throws correct error upon encountering NAs
+
 # seriation 1.3.6 (07/14/2022)
 
 ## New Features

--- a/R/seriate.dist.R
+++ b/R/seriate.dist.R
@@ -23,17 +23,13 @@ seriate.dist <-
     method = "Spectral",
     control = NULL,
     ...) {
-    if (!all(x >= 0))
-      stop("Negative distances not supported!")
 
     ## add ... to control
     control <- c(control, list(...))
 
     ## check x
-    if (any(is.na(x)))
-      stop("NAs not allowed in x!")
-    if (any(x < 0))
-      stop("No negative values allowed in x!")
+    if (anyNA(x)) stop("NAs not allowed in distance matrix x!")
+    if (any(x < 0)) stop("Negative distances not supported!")
 
     if (!is.character(method) || (length(method) != 1L))
       stop("Argument 'method' must be a character string.")

--- a/tests/testthat/test-seriate.R
+++ b/tests/testthat/test-seriate.R
@@ -27,6 +27,16 @@ expect_true(all(sapply(os, length) == nrow(x)))
 # TODO: check labels
 #get_order(os$Identity)
 
+# check seriate errors for bad dist objects
+test_that("negative distances and NAs prompt correct seriate.dist errors", {
+  dNeg <- d
+  dNeg[1] <- -1
+  expect_error(seriate(dNeg), "Negative distances not supported")
+
+  dNA <- d
+  dNA[1] <- NA
+  expect_error(seriate(dNA), "NAs not allowed in distance matrix x")
+})
 
 ### Stress test to find memory access problems with randomized algorithms
 #context("memory stress test")


### PR DESCRIPTION
Thanks for this useful package! :)

I noticed that seriate.dist checks for NAs and negative values in the distance matrix in the wrong order, leading to a less helpful error message on NAs. 

This small pull request is to fix that.