### PR TITLE
seriate preserves names/labels of input data and get_order returns named integers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: seriation
 Type: Package
 Title: Infrastructure for Ordering Objects Using Seriation
-Version: 1.3.6.9000
+Version: 1.4.0.9000
 Date: 2022-07-14
 Authors@R: c(
 	person("Michael", "Hahsler", role = c("aut", "cre", "cph"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # seriation (development version)
 
+# seriation 1.4.0
+
 ## New Features
 -   seriate for arrays (including matrices) now returns a complete ser_permutation for all
     dimensions even if margins are specified. For not specified margins, identity permutations

--- a/R/get_order.R
+++ b/R/get_order.R
@@ -71,7 +71,8 @@ get_order.ser_permutation <-
 #' @rdname get_order
 #' @export
 get_order.hclust <- function(x, ...)
-  x$order
+  structure(.Data = x$order, names = x$labels[x$order])
+
 
 #' @rdname get_order
 #' @export

--- a/R/permute.R
+++ b/R/permute.R
@@ -234,7 +234,7 @@ permute.hclust <- function(x, order, ...) {
     stop("some permutation vectors do not fit dimension of data")
 
   # check dist
-  if (attr(x, "Diag") || attr(x, "Upper"))
+  if (isTRUE(attr(x, "Diag")) || isTRUE(attr(x, "Upper")))
     stop("'dist' with diagonal or upper triangle matrix not implemented")
 }
 

--- a/R/ser_permutation_vector.R
+++ b/R/ser_permutation_vector.R
@@ -94,7 +94,9 @@ ser_permutation_vector <- function(x, method = NULL) {
     x <- NA_integer_
     attr(x, "method") <- "identity permutation"
   } else if (is.numeric(x)) {
+    nm <- names(x)
     x <- as.integer(x)
+    names(x) <- nm
   } else if (inherits(x, "ser_permutation") && length(x) == 1) {
     x <- x[[1]]
   } else {

--- a/R/seriate.dist.R
+++ b/R/seriate.dist.R
@@ -41,6 +41,7 @@ seriate.dist <-
         method$description, "\n\n", sep = "")
 
     order <- method$fun(x, control = control)
+    if (is.integer(order)) names(order) <- labels(x)[order]
 
     ser_permutation(ser_permutation_vector(order, method = method$name))
   }
@@ -50,7 +51,6 @@ seriate_dist_identity <- function(x, control = NULL) {
   .get_parameters(control, NULL)
 
   o <- 1:attr(x, "Size")
-  names(o) <- labels(x)
   o
 }
 
@@ -59,7 +59,6 @@ seriate_dist_random <- function(x, control = NULL) {
   .get_parameters(control, NULL)
 
   o <- 1:attr(x, "Size")
-  names(o) <- labels(x)
   sample(o)
 }
 

--- a/R/seriate_ARSA_Branch-Bound.R
+++ b/R/seriate_ARSA_Branch-Bound.R
@@ -74,7 +74,6 @@ seriate_dist_arsa <- function(x, control = NULL) {
   )
 
   o <- ret[[6]]
-  names(o) <- labels(x)[o]
 
   ### ARSA returns all 0's in some cases
   if (all(o == 0)) {
@@ -113,7 +112,6 @@ seriate_dist_bburcg <- function(x, control = NULL) {
     param$verbose)
 
   o <- ret[[4]]
-  names(o) <- labels(x)[o]
   o
 }
 
@@ -140,7 +138,6 @@ seriate_dist_bbwrcg <- function(x, control = NULL) {
     param$verbose)
 
   o <- ret[[4]]
-  names(o) <- labels(x)[o]
   o
 }
 

--- a/R/seriate_R2E.R
+++ b/R/seriate_R2E.R
@@ -50,7 +50,6 @@ seriate_dist_chen <- function(x, control = NULL) {
   left <- left[order(e[left, 2])]
 
   o <- c(right, left)
-  names(o) <- labels(x)[o]
   o
 }
 

--- a/R/seriate_SPIN.R
+++ b/R/seriate_SPIN.R
@@ -120,7 +120,6 @@ seriate_dist_SPIN <- function(x, control = NULL) {
   if (verbose)
     cat("Best Energy:", energy_best, "\n")
   o <- permutation_matrix2vector(P_best)
-  names(o) <- names(x)[o]
   o
 }
 
@@ -213,7 +212,6 @@ seriate_dist_SPIN_STS <- function(x, control = NULL) {
   if (verbose)
     cat("Overall best Energy:", min(energy), "\n")
   o <- res[[which.min(energy)]]
-  names(o) <- names(x)[o]
   o
 }
 

--- a/R/seriate_TSP.R
+++ b/R/seriate_TSP.R
@@ -32,7 +32,6 @@ seriate_dist_tsp <- function(x, control = NULL) {
     control = control)
 
   o <- cut_tour(tour, cut = "cut_here", exclude_cut = TRUE)
-  names(o) <- labels(x)[o]
   o
 }
 

--- a/R/seriate_VAT.R
+++ b/R/seriate_VAT.R
@@ -44,7 +44,6 @@ seriate_dist_VAT <- function(x, control = NULL) {
     I[j] <- TRUE
   }
 
-  names(P) <- labels(x)[P]
   P
 }
 

--- a/R/seriate_spectral.R
+++ b/R/seriate_spectral.R
@@ -38,7 +38,6 @@ seriate_dist_spectral <- function(x, control = NULL) {
   q <- eigen(L)
   fiedler <- q$vectors[, ncol(W) - 1L]
   o <- order(fiedler)
-  names(o) <- names(x)[o]
   o
 }
 
@@ -57,7 +56,6 @@ seriate_dist_spectral_norm <- function(x, control = NULL) {
   ## look for the vector with the largest eigenvalue
   largest_ev <- q[, 2L]
   o <- order(largest_ev)
-  names(o) <- names(x)[o]
   o
 }
 

--- a/tests/testthat/_snaps/seriate.md
+++ b/tests/testthat/_snaps/seriate.md
@@ -175,11 +175,11 @@
 # data.frame seriation works as expected
 
     Code
-      permute(df, o)
+      permute(df, oPCA)
     Output
-        A B C D E
+        B A C D E
       a 1 1 0 0 0
       b 1 1 1 0 0
-      d 1 0 1 1 1
+      d 0 1 1 1 1
       c 0 0 1 1 1
 

--- a/tests/testthat/_snaps/seriate.md
+++ b/tests/testthat/_snaps/seriate.md
@@ -1,0 +1,185 @@
+# seriate.dist returns expected results
+
+    Code
+      str(os[deterMethods])
+    Output
+      List of 20
+       $ BBURCG       : 'ser_permutation_vector' Named int [1:4] 1 2 4 3
+        ..- attr(*, "names")= chr [1:4] "a" "b" "d" "c"
+        ..- attr(*, "method")= chr "BBURCG"
+       $ BBWRCG       : 'ser_permutation_vector' Named int [1:4] 1 2 4 3
+        ..- attr(*, "names")= chr [1:4] "a" "b" "d" "c"
+        ..- attr(*, "method")= chr "BBWRCG"
+       $ GW           :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -4 1 -2 -3 2
+        ..$ height     : num [1:3] 1 1 2.24
+        ..$ order      : int [1:4] 1 2 4 3
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "complete"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "GW"
+       $ GW_average   :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -4 1 -2 -3 2
+        ..$ height     : num [1:3] 1 1 1.99
+        ..$ order      : int [1:4] 1 2 4 3
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "average"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "GW_average"
+       $ GW_complete  :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -4 1 -2 -3 2
+        ..$ height     : num [1:3] 1 1 2.24
+        ..$ order      : int [1:4] 1 2 4 3
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "complete"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "GW_complete"
+       $ GW_single    :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -4 1 -2 -3 2
+        ..$ height     : num [1:3] 1 1 1.73
+        ..$ order      : int [1:4] 1 2 4 3
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "single"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "GW_single"
+       $ GW_ward      :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -4 1 -2 -3 2
+        ..$ height     : num [1:3] 1 1 2.65
+        ..$ order      : int [1:4] 1 2 4 3
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "ward.D2"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "GW_ward"
+       $ HC           :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -3 1 -2 -4 2
+        ..$ height     : num [1:3] 1 1 2.24
+        ..$ order      : int [1:4] 1 2 3 4
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "complete"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "HC"
+       $ HC_average   :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -3 1 -2 -4 2
+        ..$ height     : num [1:3] 1 1 1.99
+        ..$ order      : int [1:4] 1 2 3 4
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "average"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "HC_average"
+       $ HC_complete  :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -3 1 -2 -4 2
+        ..$ height     : num [1:3] 1 1 2.24
+        ..$ order      : int [1:4] 1 2 3 4
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "complete"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "HC_complete"
+       $ HC_single    :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -3 1 -2 -4 2
+        ..$ height     : num [1:3] 1 1 1.73
+        ..$ order      : int [1:4] 1 2 3 4
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "single"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "HC_single"
+       $ HC_ward      :Classes 'ser_permutation_vector', 'hclust'  hidden list of 7
+        ..$ merge      : int [1:3, 1:2] -1 -3 1 -2 -4 2
+        ..$ height     : num [1:3] 1 1 2.65
+        ..$ order      : int [1:4] 1 2 3 4
+        ..$ labels     : chr [1:4] "a" "b" "c" "d"
+        ..$ method     : chr "ward.D2"
+        ..$ call       : language hclust(d = d, method = control$method)
+        ..$ dist.method: chr "euclidean"
+        ..- attr(*, "method")= chr "HC_ward"
+       $ Identity     : 'ser_permutation_vector' Named int [1:4] 1 2 3 4
+        ..- attr(*, "names")= chr [1:4] "a" "b" "c" "d"
+        ..- attr(*, "method")= chr "Identity"
+       $ MDS          : 'ser_permutation_vector' Named int [1:4] 3 4 2 1
+        ..- attr(*, "names")= chr [1:4] "c" "d" "b" "a"
+        ..- attr(*, "method")= chr "MDS"
+       $ MDS_angle    : 'ser_permutation_vector' Named int [1:4] 1 2 4 3
+        ..- attr(*, "names")= chr [1:4] "a" "b" "d" "c"
+        ..- attr(*, "method")= chr "MDS_angle"
+       $ MDS_metric   : 'ser_permutation_vector' Named int [1:4] 3 4 2 1
+        ..- attr(*, "names")= chr [1:4] "c" "d" "b" "a"
+        ..- attr(*, "method")= chr "MDS_metric"
+       $ R2E          : 'ser_permutation_vector' Named int [1:4] 4 3 1 2
+        ..- attr(*, "names")= chr [1:4] "d" "c" "a" "b"
+        ..- attr(*, "method")= chr "R2E"
+       $ Spectral     : 'ser_permutation_vector' Named int [1:4] 3 4 2 1
+        ..- attr(*, "names")= chr [1:4] "c" "d" "b" "a"
+        ..- attr(*, "method")= chr "Spectral"
+       $ Spectral_norm: 'ser_permutation_vector' Named int [1:4] 3 4 2 1
+        ..- attr(*, "names")= chr [1:4] "c" "d" "b" "a"
+        ..- attr(*, "method")= chr "Spectral_norm"
+       $ VAT          : 'ser_permutation_vector' Named int [1:4] 3 4 2 1
+        ..- attr(*, "names")= chr [1:4] "c" "d" "b" "a"
+        ..- attr(*, "method")= chr "VAT"
+
+# seriate.matrix returns expected results
+
+    Code
+      str(os[deterMethods])
+    Output
+      List of 5
+       $ CA       :List of 2
+        ..$ : 'ser_permutation_vector' Named int [1:4] 1 2 4 3
+        .. ..- attr(*, "names")= chr [1:4] "a" "b" "c" "d"
+        .. ..- attr(*, "method")= chr "CA"
+        ..$ : 'ser_permutation_vector' Named int [1:5] 2 1 3 4 5
+        .. ..- attr(*, "names")= chr [1:5] "A" "B" "C" "D" ...
+        .. ..- attr(*, "method")= chr "CA"
+        ..- attr(*, "class")= chr [1:2] "ser_permutation" "list"
+       $ Identity :List of 2
+        ..$ : 'ser_permutation_vector' Named int [1:4] 1 2 3 4
+        .. ..- attr(*, "names")= chr [1:4] "a" "b" "c" "d"
+        .. ..- attr(*, "method")= chr "Identity"
+        ..$ : 'ser_permutation_vector' Named int [1:5] 1 2 3 4 5
+        .. ..- attr(*, "names")= chr [1:5] "A" "B" "C" "D" ...
+        .. ..- attr(*, "method")= chr "Identity"
+        ..- attr(*, "class")= chr [1:2] "ser_permutation" "list"
+       $ PCA      :List of 2
+        ..$ : 'ser_permutation_vector' Named int [1:4] 1 2 4 3
+        .. ..- attr(*, "names")= chr [1:4] "a" "b" "c" "d"
+        .. ..- attr(*, "method")= chr "PCA"
+        ..$ : 'ser_permutation_vector' Named int [1:5] 2 1 3 4 5
+        .. ..- attr(*, "names")= chr [1:5] "A" "B" "C" "D" ...
+        .. ..- attr(*, "method")= chr "PCA"
+        ..- attr(*, "class")= chr [1:2] "ser_permutation" "list"
+       $ PCA_angle:List of 2
+        ..$ : 'ser_permutation_vector' Named int [1:4] 1 2 4 3
+        .. ..- attr(*, "names")= chr [1:4] "a" "b" "c" "d"
+        .. ..- attr(*, "method")= chr "PCA_angle"
+        ..$ : 'ser_permutation_vector' Named int [1:5] 4 5 3 1 2
+        .. ..- attr(*, "names")= chr [1:5] "A" "B" "C" "D" ...
+        .. ..- attr(*, "method")= chr "PCA_angle"
+        ..- attr(*, "class")= chr [1:2] "ser_permutation" "list"
+       $ Reverse  :List of 2
+        ..$ : 'ser_permutation_vector' Named int [1:4] 4 3 2 1
+        .. ..- attr(*, "names")= chr [1:4] "a" "b" "c" "d"
+        .. ..- attr(*, "method")= chr "Reverse"
+        ..$ : 'ser_permutation_vector' Named int [1:5] 5 4 3 2 1
+        .. ..- attr(*, "names")= chr [1:5] "A" "B" "C" "D" ...
+        .. ..- attr(*, "method")= chr "Reverse"
+        ..- attr(*, "class")= chr [1:2] "ser_permutation" "list"
+
+# data.frame seriation works as expected
+
+    Code
+      permute(df, o)
+    Output
+        A B C D E
+      a 1 1 0 0 0
+      b 1 1 1 0 0
+      d 1 0 1 1 1
+      c 0 0 1 1 1
+

--- a/tests/testthat/test-permuation_vector.R
+++ b/tests/testthat/test-permuation_vector.R
@@ -76,12 +76,8 @@ expect_identical(permute(l, 3:1), rev(l))
 ## the check may be pointless
 dend <- as.dendrogram(hclust(d))
 
-expect_equal(dend, permute(dend, get_order(dend)))
-#,
-#  check.attributes = FALSE)
-expect_equal(rev(dend), permute(dend, rev(get_order(dend))))
-#,
-#  check.attributes = FALSE)
+expect_equal(dend, permute(dend, get_order(dend)), ignore_attr = TRUE)
+expect_equal(rev(dend), permute(dend, rev(get_order(dend))), ignore_attr = TRUE)
 
 # chances are that a random order will not be perfect
 o <- sample(5)

--- a/tests/testthat/test-seriate.R
+++ b/tests/testthat/test-seriate.R
@@ -17,9 +17,9 @@ test_that("seriate.dist returns expected results", {
   cat("\n") # for cleaner testthat output
   methods <- list_seriation_methods(kind = "dist")
   os <- sapply(methods, function(m) {
-    cat("Doing ", m, " ... ")
+    cat("Doing", format(m, width = 13), "... ")
     tm <- system.time(o <- seriate(d, method = m))
-    cat("took ", tm[3], "s.\n")
+    cat("took", formatC(tm[3], digits = 4), "s.\n")
     o
   })
   # make sure they are all the right length
@@ -104,9 +104,9 @@ test_that("seriate.matrix returns expected results", {
   cat("\n") # for cleaner testthat output
   methods <- list_seriation_methods(kind = "matrix")
   os <- sapply(methods, function(m) {
-    cat("Doing ", m, " ... ")
+    cat("Doing", format(m, width = 13), "... ")
     tm <- system.time(o <- seriate(x, method = m))
-    cat("took ", tm[3], "s.\n")
+    cat("took", formatC(tm[3], digits = 4), "s.\n")
     o
   }, simplify = FALSE)
 
@@ -114,7 +114,7 @@ test_that("seriate.matrix returns expected results", {
   expect_true(all(sapply(os, length) == 2L))
   expect_true(all(sapply(os, FUN = function(o2) sapply(o2, length)) == c(4L, 5L)))
 
-  x_p <- permute(x, os[[1]])
+  x_p <- permute(x, os[[1]]) # BEA method
   expect_equal(x_p, x[get_order(os[[1]], 1), get_order(os[[1]], 2)])
 
   # check labels
@@ -134,9 +134,9 @@ test_that("seriate.matrix with margin returns expected results", {
   cat("\n") # for cleaner testthat output
   methods <- list_seriation_methods(kind = "matrix")
   os <- sapply(methods, function(m) {
-    cat("Doing ", m, " ... ")
+    cat("Doing", format(m, width = 13), "... ")
     tm <- system.time(o <- seriate(x, method = m, margin = 2))
-    cat("took ", tm[3], "s.\n")
+    cat("took", formatC(tm[3], digits = 4), "s.\n")
     o
   }, simplify = FALSE)
 
@@ -153,17 +153,16 @@ test_that("data.frame seriation works as expected", {
 
   df <- as.data.frame(x)
   o <- seriate(df)
-  permute(df, o) # default olo is non-deterministic so no
+  expect_silent(permute(df, o)) # defaults work with no messages/warnings
 
-  seriate(df, method = "PCA")
+  expect_message(
+    permute(df, o[1]), # DEPRECATED: results in a message
+    "permute for data.frames with a single seriation order is now deprecated"
+  )
 
   o <- seriate(df, margin = 1)
-  ## DEPRECATED: results in a message
- expect_message(
-   permute(df, o[1]),
-   "permute for data.frames with a single seriation order is now deprecated"
- )
+  expect_equal(as.integer(o[[2]]), 1:5) # columns left in original order
 
- expect_snapshot(permute(df, o))
-
+  oPCA <- seriate(df, method = "PCA")
+  expect_snapshot(permute(df, oPCA))
 })

--- a/tests/testthat/test-seriate.R
+++ b/tests/testthat/test-seriate.R
@@ -7,25 +7,79 @@ x <- matrix(c(
 		0,0,1,1,1,
 		1,0,1,1,1
 		), byrow = TRUE, ncol = 5,
-  dimnames = list(1:4, LETTERS[1:5]))
+  dimnames = list(letters[1:4], LETTERS[1:5]))
 
 d <- dist(x)
 
-context("seriate_dist")
+test_that("seriate.dist returns expected results", {
+  local_edition(3) # for snapshot testing
 
-methods <- list_seriation_methods(kind = "dist")
-os <- sapply(methods, function(m) {
-  cat("Doing ", m, " ... ")
-  tm <- system.time(o <- seriate(d, method = m))
-  cat("took ", tm[3],"s.\n")
-  o
+  cat("\n") # for cleaner testthat output
+  methods <- list_seriation_methods(kind = "dist")
+  os <- sapply(methods, function(m) {
+    cat("Doing ", m, " ... ")
+    tm <- system.time(o <- seriate(d, method = m))
+    cat("took ", tm[3], "s.\n")
+    o
+  })
+  # make sure they are all the right length
+  expect_true(all(sapply(os, length) == nrow(x)))
+
+  # check which methods produce hclusts and which integers
+  hclusts <- os[sapply(os, function(x) inherits(x, "hclust"))]
+  expect_setequal(object = names(hclusts), expected = c(
+    "GW", "GW_average", "GW_complete", "GW_single", "GW_ward",
+    "HC", "HC_average", "HC_complete", "HC_single", "HC_ward",
+    "OLO", "OLO_average", "OLO_complete", "OLO_single", "OLO_ward"
+  ))
+  integers <- os[sapply(os, is.integer)]
+  expect_setequal(object = names(integers), expected = c(
+    "ARSA", "BBURCG", "BBWRCG", "Identity",
+    "MDS", "MDS_angle", "MDS_metric", "MDS_nonmetric",
+    "QAP_2SUM", "QAP_BAR", "QAP_Inertia", "QAP_LS",
+    "R2E", "Random", "SA", "Spectral", "Spectral_norm",
+    "SPIN_NH", "SPIN_STS", "TSP", "VAT"
+  ))
+  expect_setequal(c(names(hclusts), names(integers)), expected = names(os))
+
+  # check all orders are integers
+  ORDERS <- sapply(X = os, FUN = get_order, dim = 1, simplify = FALSE)
+  for (n in names(ORDERS)) expect_type(ORDERS[[!!n]], "integer") # see ?testthat::quasi_label
+
+  # check names - first sanity check before more comprehensive checks
+  expect_equal(names(get_order(os$Identity)), letters[1:4])
+
+  # check names of integer seriation vectors correspond to correct integers
+  for (n in names(integers)) {
+    expect_type(names(ORDERS[[!!n]]), "character") # i.e. not NULL
+    expect_mapequal(ORDERS[[!!n]], expected = c(a = 1, b = 2, c = 3, d = 4))
+  }
+
+  # check $labels of hclust seriation vectors remain in original input order
+  for (n in names(hclusts)) {
+    expect_equal(hclusts[[!!n]][["labels"]], expected = letters[1:4])
+  }
+
+  # check names() of hclust seriation vectors are equal to ordered labels
+  for (n in names(hclusts)) {
+    next # TODO run this test once names.ser_permutation_vector is registered
+    expect_equal(
+      object = names(hclusts[[!!n]]),
+      expected = hclusts[[n]][["labels"]][hclusts[[n]][["order"]]]
+    )
+  }
+
+  # check str snapshot of some deterministic methods
+  deterMethods <- c(
+    "BBURCG", "BBWRCG",
+    "GW", "GW_average", "GW_complete", "GW_single", "GW_ward",
+    "HC", "HC_average", "HC_complete", "HC_single", "HC_ward",
+    "Identity", "MDS", "MDS_angle", "MDS_metric",
+    "R2E", "Spectral", "Spectral_norm", "VAT"
+  )
+  expect_snapshot(str(os[deterMethods]))
+
 })
-
-# make sure they are all the right length
-expect_true(all(sapply(os, length) == nrow(x)))
-
-# TODO: check labels
-#get_order(os$Identity)
 
 # check seriate errors for bad dist objects
 test_that("negative distances and NAs prompt correct seriate.dist errors", {
@@ -44,54 +98,72 @@ test_that("negative distances and NAs prompt correct seriate.dist errors", {
 #replicate(1000, seriate(d, method="bbwrcg"))
 #replicate(1000, seriate(d, method="arsa"))
 
-context("seriate_matrix")
+test_that("seriate.matrix returns expected results", {
+  local_edition(3) # for snapshot testing
 
-methods <- list_seriation_methods(kind = "matrix")
-os <- sapply(methods, function(m) {
-  cat("Doing ", m, " ... ")
-  tm <- system.time(o <- seriate(x, method = m))
-  cat("took ", tm[3],"s.\n")
-  o
-}, simplify = FALSE)
+  cat("\n") # for cleaner testthat output
+  methods <- list_seriation_methods(kind = "matrix")
+  os <- sapply(methods, function(m) {
+    cat("Doing ", m, " ... ")
+    tm <- system.time(o <- seriate(x, method = m))
+    cat("took ", tm[3], "s.\n")
+    o
+  }, simplify = FALSE)
 
-# check number and length of orders
-expect_true(all(sapply(os, length) == 2L))
-expect_true(all(sapply(os, FUN = function(o2) sapply(o2, length)) == c(4L, 5L)))
+  # check number and length of orders
+  expect_true(all(sapply(os, length) == 2L))
+  expect_true(all(sapply(os, FUN = function(o2) sapply(o2, length)) == c(4L, 5L)))
 
-x_p <- permute(x, os[[1]])
-expect_equal(x_p, x[get_order(os[[1]], 1), get_order(os[[1]], 2)])
+  x_p <- permute(x, os[[1]])
+  expect_equal(x_p, x[get_order(os[[1]], 1), get_order(os[[1]], 2)])
 
-# TODO: check labels
-#get_order(os$Identity, 1)
-#get_order(os$Identity, 2)
-#get_order(os$Reverse, 2)
+  # check labels
+  expect_equal(get_order(os$Identity, 1), c(a = 1, b = 2, c = 3, d = 4))
+  expect_equal(get_order(os$Identity, 2), c(A = 1, B = 2, C = 3, D = 4, E = 5))
+  expect_equal(get_order(os$Reverse, 2), c(A = 5, B = 4, C = 3, D = 2, E = 1))
 
-context("seriate with margin")
+  # check snapshot of some deterministic methods
+  deterMethods <- c("CA", "Identity", "PCA", "PCA_angle", "Reverse")
+  expect_snapshot(str(os[deterMethods]))
 
-methods <- list_seriation_methods(kind = "matrix")
-os <- sapply(methods, function(m) {
-  cat("Doing ", m, " ... ")
-  tm <- system.time(o <- seriate(x, method = m, margin = 2))
-  cat("took ", tm[3],"s.\n")
-  o
-}, simplify = FALSE)
+})
 
-expect_true(all(sapply(os, length) == 2L))
-expect_true(all(sapply(os, FUN = function(o2) o2[[1]]) == 1:4))
-expect_true(all(sapply(os, FUN = function(o2) length(o2[[2]]) == 5L)))
+test_that("seriate.matrix with margin returns expected results", {
+  local_edition(3) # for snapshot testing
 
-x_p <- permute(x, os[[1]], margin = 2)
-expect_equal(x_p, x[, get_order(os[[1]], 2)])
+  cat("\n") # for cleaner testthat output
+  methods <- list_seriation_methods(kind = "matrix")
+  os <- sapply(methods, function(m) {
+    cat("Doing ", m, " ... ")
+    tm <- system.time(o <- seriate(x, method = m, margin = 2))
+    cat("took ", tm[3], "s.\n")
+    o
+  }, simplify = FALSE)
 
-context("seriate data.frame")
-df <- as.data.frame(x)
-o <- seriate(df)
-permute(df, o)
+  expect_true(all(sapply(os, length) == 2L))
+  expect_true(all(sapply(os, FUN = function(o2) o2[[1]]) == 1:4))
+  expect_true(all(sapply(os, FUN = function(o2) length(o2[[2]]) == 5L)))
 
-seriate(df, method = "PCA")
+  x_p <- permute(x, os[[1]], margin = 2)
+  expect_equal(x_p, x[, get_order(os[[1]], 2)])
+})
 
-o <- seriate(df, margin = 1)
-## DEPRECATED: results in a message
-permute(df, o[1])
+test_that("data.frame seriation works as expected", {
+  local_edition(3) # for snapshot testing
 
-permute(df, o)
+  df <- as.data.frame(x)
+  o <- seriate(df)
+  permute(df, o) # default olo is non-deterministic so no
+
+  seriate(df, method = "PCA")
+
+  o <- seriate(df, margin = 1)
+  ## DEPRECATED: results in a message
+ expect_message(
+   permute(df, o[1]),
+   "permute for data.frames with a single seriation order is now deprecated"
+ )
+
+ expect_snapshot(permute(df, o))
+
+})

--- a/tests/testthat/test-seriate.R
+++ b/tests/testthat/test-seriate.R
@@ -44,7 +44,7 @@ test_that("seriate.dist returns expected results", {
 
   # check all orders are integers
   ORDERS <- sapply(X = os, FUN = get_order, dim = 1, simplify = FALSE)
-  for (n in names(ORDERS)) expect_type(ORDERS[[!!n]], "integer") # see ?testthat::quasi_label
+  for (n in names(ORDERS)) expect_type(ORDERS[[!!n]], "integer") # see ?testthat::quasi_label RE "!!"
 
   # check names - first sanity check before more comprehensive checks
   expect_equal(names(get_order(os$Identity)), letters[1:4])
@@ -60,11 +60,10 @@ test_that("seriate.dist returns expected results", {
     expect_equal(hclusts[[!!n]][["labels"]], expected = letters[1:4])
   }
 
-  # check names() of hclust seriation vectors are equal to ordered labels
+  # check names of get_order(<hclust seriation vector>) equal to ordered labels
   for (n in names(hclusts)) {
-    next # TODO run this test once names.ser_permutation_vector is registered
     expect_equal(
-      object = names(hclusts[[!!n]]),
+      object = names(ORDERS[[!!n]]),
       expected = hclusts[[n]][["labels"]][hclusts[[n]][["order"]]]
     )
   }

--- a/tests/testthat/test-seriate.R
+++ b/tests/testthat/test-seriate.R
@@ -91,6 +91,18 @@ test_that("negative distances and NAs prompt correct seriate.dist errors", {
   expect_error(seriate(dNA), "NAs not allowed in distance matrix x")
 })
 
+test_that("dist objects without Diag or Upper attributes can be permuted", {
+  # eurodist is an object of class dist from built in R package "datasets"
+  expect_s3_class(eurodist, "dist")
+  expect_identical(attr(eurodist, "Diag"), NULL)
+  expect_identical(attr(eurodist, "Upper"), NULL)
+  s <- seriate(eurodist, method = "MDS")
+  expect_s3_class(p <- permute(eurodist, order = s), "dist")
+  expect_false(attr(p, "Diag")) # permutation adds Diag, is this desirable?
+  expect_false(attr(p, "Upper"))
+  expect_equal(labels(p), names(get_order(s)))
+})
+
 ### Stress test to find memory access problems with randomized algorithms
 #context("memory stress test")
 #replicate(1000, seriate(d, method="bburcg"))


### PR DESCRIPTION
Hi again, 

I would like it if the integers returned by get_order() were named, according to the names or dist labels of the original data. I believe this might have already been the intended behaviour, as I noticed there is already some code inside seriate and its subroutines aimed towards preserving the input names, but this wasn't always ultimately seen in the output object. 

This pull request makes the preservation of names more consistent, and get_order now always returns named integers. (Either directly using named integers when the ser_permutation_vector has class integer, or by returning reordered hclust labels, when the ser_permutation_vector has class hclust) 

I added tests to test-seriate.R to try and ensure I didn't break anything by doing this, and to ensure the returned names are correctly aligned to the integer order.
All tests pass on my M1 mac and on Windows (with https://win-builder.r-project.org/)
and I can't see any obvious reasons why adding names to the order integers would break any other existing code using seriation.

happy to hear any feedback, and thanks again for your work on this package,
David

### Demonstration of new behaviour (see below for old behaviour):

``` r
# remotes::install_github("david-barnett/seriation@master")
library(seriation)
packageVersion("seriation")
#> [1] '1.4.0.9000'

class(eurodist)
#> [1] "dist"
pimage(eurodist)
```

![](https://i.imgur.com/ZPYCedN.png)

``` r

# methods like MDS produce integer ser_permutation_vector objects, now with names!
mds <- seriate(eurodist, method = "MDS")
class(mds[[1]])
#> [1] "ser_permutation_vector" "integer"
get_order(mds) # now with names
#>       Gibraltar          Lisbon          Madrid       Barcelona       Cherbourg 
#>               9              12              14               2               5 
#>      Marseilles           Lyons           Paris          Calais          Geneva 
#>              15              13              18               4               8 
#>        Brussels Hook of Holland           Milan         Cologne         Hamburg 
#>               3              11              16               6              10 
#>          Munich      Copenhagen            Rome       Stockholm          Vienna 
#>              17               7              19              20              21 
#>          Athens 
#>               1

# methods like OLO produce hclust ser_permutation_vector objects, get_order now returns names!
olo <- seriate(eurodist, method = "olo")
class(olo[[1]])
#> [1] "ser_permutation_vector" "hclust"
get_order(olo) # names of integer order are obtained by ordering hclust labels
#>          Athens            Rome       Gibraltar          Lisbon          Madrid 
#>               1              19               9              12              14 
#>       Barcelona      Marseilles           Lyons          Geneva           Milan 
#>               2              15              13               8              16 
#>          Munich          Vienna         Cologne Hook of Holland        Brussels 
#>              17              21               6              11               3 
#>       Cherbourg           Paris          Calais         Hamburg      Copenhagen 
#>               5              18               4              10               7 
#>       Stockholm 
#>              20
identical(x = names(get_order(olo)), y = olo[[1]]$labels[olo[[1]]$order])
#> [1] TRUE

plot(olo[[1]])
```

![](https://i.imgur.com/4bgH5tN.png)

``` r

# can permute eurodist after another small bug fix (not previously possible due to missing Diag attribute)
class(permute(eurodist, mds))
#> [1] "dist"
pimage(x = eurodist, order = mds)
```

![](https://i.imgur.com/0AgGg79.png)

<sup>Created on 2022-10-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.2.1 (2022-06-23)
#>  os       macOS Ventura 13.0
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_GB.UTF-8
#>  ctype    en_GB.UTF-8
#>  tz       Europe/Amsterdam
#>  date     2022-10-30
#>  pandoc   2.18 @ /Applications/RStudio.app/Contents/MacOS/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  ca            0.71.1     2020-01-24 [1] CRAN (R 4.2.0)
#>  cli           3.4.1      2022-09-23 [1] CRAN (R 4.2.0)
#>  codetools     0.2-18     2020-11-04 [1] CRAN (R 4.2.1)
#>  colorspace    2.0-3      2022-02-21 [1] CRAN (R 4.2.0)
#>  curl          4.3.2      2021-06-23 [1] CRAN (R 4.2.0)
#>  digest        0.6.29     2021-12-01 [1] CRAN (R 4.2.0)
#>  evaluate      0.15       2022-02-18 [1] CRAN (R 4.2.0)
#>  fansi         1.0.3      2022-03-24 [1] CRAN (R 4.2.0)
#>  fastmap       1.1.0      2021-01-25 [1] CRAN (R 4.2.0)
#>  foreach       1.5.2      2022-02-02 [1] CRAN (R 4.2.0)
#>  fs            1.5.2      2021-12-08 [1] CRAN (R 4.2.0)
#>  glue          1.6.2      2022-02-24 [1] CRAN (R 4.2.0)
#>  highr         0.9        2021-04-16 [1] CRAN (R 4.2.0)
#>  htmltools     0.5.3      2022-07-18 [1] CRAN (R 4.2.0)
#>  httr          1.4.3      2022-05-04 [1] CRAN (R 4.2.0)
#>  iterators     1.0.14     2022-02-05 [1] CRAN (R 4.2.0)
#>  knitr         1.40       2022-08-24 [1] CRAN (R 4.2.0)
#>  lifecycle     1.0.3      2022-10-07 [1] CRAN (R 4.2.0)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.2.0)
#>  mime          0.12       2021-09-28 [1] CRAN (R 4.2.0)
#>  pillar        1.8.1      2022-08-19 [1] CRAN (R 4.2.0)
#>  pkgconfig     2.0.3      2019-09-22 [1] CRAN (R 4.2.0)
#>  purrr         0.3.5      2022-10-06 [1] CRAN (R 4.2.0)
#>  R.cache       0.15.0     2021-04-30 [1] CRAN (R 4.2.0)
#>  R.methodsS3   1.8.1      2020-08-26 [1] CRAN (R 4.2.0)
#>  R.oo          1.24.0     2020-08-26 [1] CRAN (R 4.2.0)
#>  R.utils       2.11.0     2021-09-26 [1] CRAN (R 4.2.0)
#>  R6            2.5.1      2021-08-19 [1] CRAN (R 4.2.0)
#>  registry      0.5-1      2019-03-05 [1] CRAN (R 4.2.0)
#>  rematch2      2.1.2      2020-05-01 [1] CRAN (R 4.2.0)
#>  reprex        2.0.1      2021-08-05 [1] CRAN (R 4.2.0)
#>  rlang         1.0.6      2022-09-24 [1] CRAN (R 4.2.0)
#>  rmarkdown     2.16       2022-08-24 [1] CRAN (R 4.2.0)
#>  rstudioapi    0.14       2022-08-22 [1] CRAN (R 4.2.0)
#>  seriation   * 1.4.0.9000 2022-10-30 [1] Github (david-barnett/seriation@6cdffee)
#>  sessioninfo   1.2.2      2021-12-06 [1] CRAN (R 4.2.0)
#>  stringi       1.7.8      2022-07-11 [1] CRAN (R 4.2.0)
#>  stringr       1.4.1      2022-08-20 [1] CRAN (R 4.2.0)
#>  styler        1.7.0      2022-03-13 [1] CRAN (R 4.2.0)
#>  tibble        3.1.8      2022-07-22 [1] CRAN (R 4.2.0)
#>  TSP           1.2-1      2022-07-14 [1] CRAN (R 4.2.0)
#>  utf8          1.2.2      2021-07-24 [1] CRAN (R 4.2.0)
#>  vctrs         0.4.2      2022-09-29 [1] CRAN (R 4.2.0)
#>  withr         2.5.0      2022-03-03 [1] CRAN (R 4.2.0)
#>  xfun          0.31       2022-05-10 [1] CRAN (R 4.2.0)
#>  xml2          1.3.3      2021-11-30 [1] CRAN (R 4.2.0)
#>  yaml          2.3.5      2022-02-21 [1] CRAN (R 4.2.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.2-arm64/Resources/library
#> 
#> ───────────────────────────────────────────────────────────────────────────
```

</details>


### Old behaviour demonstrated

``` r
# install.packages("seriation") # get cran version
library(seriation)
packageVersion("seriation")
#> [1] '1.4.0'

# examples use built-in R distance dataset eurodist
class(eurodist)
#> [1] "dist"
pimage(eurodist)
```

![](https://i.imgur.com/OZZYCER.png)

``` r

# methods like MDS produce integer ser_permutation_vector objects, with no names
mds <- seriate(eurodist, method = "MDS")
class(mds[[1]])
#> [1] "ser_permutation_vector" "integer"
get_order(mds) # no names
#>  [1]  9 12 14  2  5 15 13 18  4  8  3 11 16  6 10 17  7 19 20 21  1
names(get_order(mds))
#> NULL

# methods like OLO produce hclust ser_permutation_vector objects, with no names
olo <- seriate(eurodist, method = "olo")
class(olo[[1]])
#> [1] "ser_permutation_vector" "hclust"
get_order(olo) # no names
#>  [1]  1 19  9 12 14  2 15 13  8 16 17 21  6 11  3  5 18  4 10  7 20
names(get_order(olo))
#> NULL
olo[[1]]$labels[olo[[1]]$order] # labels and order can be used
#>  [1] "Athens"          "Rome"            "Gibraltar"       "Lisbon"         
#>  [5] "Madrid"          "Barcelona"       "Marseilles"      "Lyons"          
#>  [9] "Geneva"          "Milan"           "Munich"          "Vienna"         
#> [13] "Cologne"         "Hook of Holland" "Brussels"        "Cherbourg"      
#> [17] "Paris"           "Calais"          "Hamburg"         "Copenhagen"     
#> [21] "Stockholm"

# note: a different small bug
permute(eurodist, mds) # can't permute eurodist as it lacks Diag and Upper attributes
#> Error in attr(x, "Diag") || attr(x, "Upper"): invalid 'x' type in 'x || y'
pimage(x = eurodist, order = mds)
#> Error in attr(x, "Diag") || attr(x, "Upper"): invalid 'x' type in 'x || y'
```

<sup>Created on 2022-10-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.2.1 (2022-06-23)
#>  os       macOS Ventura 13.0
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_GB.UTF-8
#>  ctype    en_GB.UTF-8
#>  tz       Europe/Amsterdam
#>  date     2022-10-30
#>  pandoc   2.18 @ /Applications/RStudio.app/Contents/MacOS/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version date (UTC) lib source
#>  ca            0.71.1  2020-01-24 [1] CRAN (R 4.2.0)
#>  cli           3.4.1   2022-09-23 [1] CRAN (R 4.2.0)
#>  codetools     0.2-18  2020-11-04 [1] CRAN (R 4.2.1)
#>  colorspace    2.0-3   2022-02-21 [1] CRAN (R 4.2.0)
#>  curl          4.3.2   2021-06-23 [1] CRAN (R 4.2.0)
#>  digest        0.6.29  2021-12-01 [1] CRAN (R 4.2.0)
#>  evaluate      0.15    2022-02-18 [1] CRAN (R 4.2.0)
#>  fansi         1.0.3   2022-03-24 [1] CRAN (R 4.2.0)
#>  fastmap       1.1.0   2021-01-25 [1] CRAN (R 4.2.0)
#>  foreach       1.5.2   2022-02-02 [1] CRAN (R 4.2.0)
#>  fs            1.5.2   2021-12-08 [1] CRAN (R 4.2.0)
#>  glue          1.6.2   2022-02-24 [1] CRAN (R 4.2.0)
#>  highr         0.9     2021-04-16 [1] CRAN (R 4.2.0)
#>  htmltools     0.5.3   2022-07-18 [1] CRAN (R 4.2.0)
#>  httr          1.4.3   2022-05-04 [1] CRAN (R 4.2.0)
#>  iterators     1.0.14  2022-02-05 [1] CRAN (R 4.2.0)
#>  knitr         1.40    2022-08-24 [1] CRAN (R 4.2.0)
#>  lifecycle     1.0.3   2022-10-07 [1] CRAN (R 4.2.0)
#>  magrittr      2.0.3   2022-03-30 [1] CRAN (R 4.2.0)
#>  mime          0.12    2021-09-28 [1] CRAN (R 4.2.0)
#>  pillar        1.8.1   2022-08-19 [1] CRAN (R 4.2.0)
#>  pkgconfig     2.0.3   2019-09-22 [1] CRAN (R 4.2.0)
#>  purrr         0.3.5   2022-10-06 [1] CRAN (R 4.2.0)
#>  R.cache       0.15.0  2021-04-30 [1] CRAN (R 4.2.0)
#>  R.methodsS3   1.8.1   2020-08-26 [1] CRAN (R 4.2.0)
#>  R.oo          1.24.0  2020-08-26 [1] CRAN (R 4.2.0)
#>  R.utils       2.11.0  2021-09-26 [1] CRAN (R 4.2.0)
#>  R6            2.5.1   2021-08-19 [1] CRAN (R 4.2.0)
#>  registry      0.5-1   2019-03-05 [1] CRAN (R 4.2.0)
#>  reprex        2.0.1   2021-08-05 [1] CRAN (R 4.2.0)
#>  rlang         1.0.6   2022-09-24 [1] CRAN (R 4.2.0)
#>  rmarkdown     2.16    2022-08-24 [1] CRAN (R 4.2.0)
#>  rstudioapi    0.14    2022-08-22 [1] CRAN (R 4.2.0)
#>  seriation   * 1.4.0   2022-10-21 [1] CRAN (R 4.2.0)
#>  sessioninfo   1.2.2   2021-12-06 [1] CRAN (R 4.2.0)
#>  stringi       1.7.8   2022-07-11 [1] CRAN (R 4.2.0)
#>  stringr       1.4.1   2022-08-20 [1] CRAN (R 4.2.0)
#>  styler        1.7.0   2022-03-13 [1] CRAN (R 4.2.0)
#>  tibble        3.1.8   2022-07-22 [1] CRAN (R 4.2.0)
#>  TSP           1.2-1   2022-07-14 [1] CRAN (R 4.2.0)
#>  utf8          1.2.2   2021-07-24 [1] CRAN (R 4.2.0)
#>  vctrs         0.4.2   2022-09-29 [1] CRAN (R 4.2.0)
#>  withr         2.5.0   2022-03-03 [1] CRAN (R 4.2.0)
#>  xfun          0.31    2022-05-10 [1] CRAN (R 4.2.0)
#>  xml2          1.3.3   2021-11-30 [1] CRAN (R 4.2.0)
#>  yaml          2.3.5   2022-02-21 [1] CRAN (R 4.2.0)
#> 
#>  [1] /Library/Frameworks/R.framework/Versions/4.2-arm64/Resources/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>